### PR TITLE
Allow configuring tags

### DIFF
--- a/src/ConfigureLogging.php
+++ b/src/ConfigureLogging.php
@@ -51,7 +51,7 @@ class ConfigureLogging extends BootstrapConfigureLogging
         $host = $configure['host'] ? $configure['host'] : FluentLogger::DEFAULT_ADDRESS;
         $port = $configure['port'] ? $configure['port'] : FluentLogger::DEFAULT_LISTEN_PORT;
         $options = $configure['options'] ? $configure['options'] : [];
-        $tagFormat = $configure['tagFormat'] ? $configure['tagFormat'] : null;
+        $tagFormat = isset($configure['tagFormat']) ? $configure['tagFormat'] : null;
         $log->useFluentLogger($host, $port, $options, $tagFormat);
     }
 }

--- a/src/ConfigureLogging.php
+++ b/src/ConfigureLogging.php
@@ -51,6 +51,7 @@ class ConfigureLogging extends BootstrapConfigureLogging
         $host = $configure['host'] ? $configure['host'] : FluentLogger::DEFAULT_ADDRESS;
         $port = $configure['port'] ? $configure['port'] : FluentLogger::DEFAULT_LISTEN_PORT;
         $options = $configure['options'] ? $configure['options'] : [];
-        $log->useFluentLogger($host, $port, $options);
+        $tagFormat = $configure['tagFormat'] ? $configure['tagFormat'] : null;
+        $log->useFluentLogger($host, $port, $options, $tagFormat);
     }
 }

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -36,7 +36,7 @@ class Writer extends \Illuminate\Log\Writer
      * @param  string  $level
      * @return \Psr\Log\LoggerInterface
      */
-    public function useFluentLogger($host, $port, $options = [], $tagFormat, $level = 'debug')
+    public function useFluentLogger($host, $port, $options = [], $tagFormat = null, $level = 'debug')
     {
         return $this->monolog->pushHandler(
             new FluentHandler(

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -36,11 +36,12 @@ class Writer extends \Illuminate\Log\Writer
      * @param  string  $level
      * @return \Psr\Log\LoggerInterface
      */
-    public function useFluentLogger($host, $port, $options = [], $level = 'debug')
+    public function useFluentLogger($host, $port, $options = [], $tagFormat, $level = 'debug')
     {
         return $this->monolog->pushHandler(
             new FluentHandler(
                 new FluentLogger($host, $port, $options, $this->packer),
+                $tagFormat,
                 $this->parseLevel($level)
             )
         );

--- a/src/config/fluent.php
+++ b/src/config/fluent.php
@@ -21,4 +21,6 @@ return [
     'port' => env('FLUENTD_PORT', 24224),
 
     'options' => [],
+
+    //'tagFormat' => '{{channel}}.{{level_name}}',
 ];

--- a/tests/FluentHandlerTest.php
+++ b/tests/FluentHandlerTest.php
@@ -28,7 +28,7 @@ class FluentHandlerTest extends \TestCase
             'extra' => [],
             'channel' => 'testing',
             'level_name' => 'testing',
-            'context' => 'testing'
+            'context' => ['testing']
         ]);
         $this->assertFileExists(__DIR__ . '/tmp/put.log');
         $log = $this->filesystem->get(__DIR__ . '/tmp/put.log');


### PR DESCRIPTION
Allow tags to be configured other than "{$record['channel']}.{$record['level_name']}" (which is current value).

The tag format can be configured by setting it in the configuration file fluent.php. The tag should be in the following format `somestring{{record_key_name1}}somestring{{record_key_name2}}...`

Examples:
- {{channel}}.{{level_name}} => default value, example tag: local.INFO
- {{channel}}.service_portal.{{level_name}} => default value, example tag: local.service_portal.INFO