### PR TITLE
putting exception trace in context when the context is an exception

### DIFF
--- a/src/FluentHandler.php
+++ b/src/FluentHandler.php
@@ -124,7 +124,7 @@ class FluentHandler extends AbstractProcessingHandler
 
     protected function getContextExceptionTrace($context)
     {
-        return $context['exception']->getTrace();
+        return $context['exception']->getTraceAsString();
     }
     
     /**

--- a/src/FluentHandler.php
+++ b/src/FluentHandler.php
@@ -105,7 +105,7 @@ class FluentHandler extends AbstractProcessingHandler
      * returns the context
      * @return array
      */
-    protected function getContext($context)
+    protected function getContext($context): array
     {
         if ($this->contextHasException($context)) {
             return $this->getContextExceptionTrace($context);
@@ -113,7 +113,12 @@ class FluentHandler extends AbstractProcessingHandler
         return $context;
     }
 
-    protected function contextHasException($context)
+    /**
+     * Identifies the content type of the given $context
+     * @param  mixed $context
+     * @return bool
+     */
+    protected function contextHasException($context): bool
     {
         return (
                 is_array($context)
@@ -122,7 +127,12 @@ class FluentHandler extends AbstractProcessingHandler
         );
     }
 
-    protected function getContextExceptionTrace($context)
+    /**
+     * Returns the entire exception trace as a string
+     * @param  array $context
+     * @return string
+     */
+    protected function getContextExceptionTrace(array $context): string
     {
         return $context['exception']->getTraceAsString();
     }

--- a/src/FluentHandler.php
+++ b/src/FluentHandler.php
@@ -65,7 +65,7 @@ class FluentHandler extends AbstractProcessingHandler
             $tag,
             [
                 'message' => $record['message'],
-                'context' => $record['context'],
+                'context' => $this->getContext($record['context']),
                 'extra'   => $record['extra'],
             ]
         );
@@ -101,6 +101,32 @@ class FluentHandler extends AbstractProcessingHandler
         return $tag;
     }
 
+    /**
+     * returns the context
+     * @return array
+     */
+    protected function getContext($context)
+    {
+        if ($this->contextHasException($context)) {
+            return $this->getContextExceptionTrace($context);
+        }
+        return $context;
+    }
+
+    protected function contextHasException($context)
+    {
+        return (
+                is_array($context)
+            && array_key_exists('exception', $context)
+            && $context['exception'] instanceof \Exception
+        );
+    }
+
+    protected function getContextExceptionTrace($context)
+    {
+        return $context['exception']->getTrace();
+    }
+    
     /**
      * @return LoggerInterface
      */


### PR DESCRIPTION
Laravel puts the entire `Exception` inside the context. When `json_encode` is applied to the context, the `Exception` returns an empty object, as it has no public properties.

This fix will put the Exception trace inside the context.