### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
     "php": "^7.0",
     "fluent/logger": "^1.0",
     "illuminate/log": "^5.5",
-    "illuminate/support": "^5.5",
-    "illuminate/config": "^5.5",
-    "illuminate/contracts": "^5.5",
-    "illuminate/container": "^5.5"
+    "illuminate/support": "5.5.*",
+    "illuminate/config": "5.5.*",
+    "illuminate/contracts": "5.5.*",
+    "illuminate/container": "5.5.*"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0",


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.