### PR TITLE
Added option to configure FluentHandler

### DIFF
--- a/src/config/fluent.php
+++ b/src/config/fluent.php
@@ -28,5 +28,8 @@ return [
     // specified class name
     'packer' => null,
 
+    // optionally override FluentHandler-class to customize behaviour
+    'handler' => null,
+
     'tagFormat' => '{{channel}}.{{level_name}}',
 ];


### PR DESCRIPTION
This merge request introduces configurable `FluentHandler`-class in `fluent.php` config.
This brings more flexibility when it comes to preparing data.

For example we wanted to have more control about what is sent to our logging instance. `JsonPacker` was not enough, as you can't access the raw-`$record["context"]`.

We created a class which extends the stock `\Ytake\LaravelFluent\FluentHandler`. 
```php
class FluentHandler extends \Ytake\LaravelFluent\FluentHandler
{
    protected function write(array $record)
    {
        $tag = $this->populateTag($record);

        $this->logger->post(
            $tag,
            [
                'message' => $record['message'],
                'level' => $record['level'],
                'level_name' => $record['level_name'],
                'context' => $this->getContext($record['context']),
                'extra' => $record['extra'],
            ]
        );
    }

    /**
     * returns the context.
     *
     * @param mixed $context
     *
     * @return array
     */
    protected function getContext($context)
    {
        if ($this->contextHasException($context)) {
            return $this->getContextException($context);
        }

        return $context;
    }

    protected function getContextException(array $context): array
    {
        return [
            'exceptionTrace' => $context['exception']->getTraceAsString(),
            'exceptionClass' => get_class($context['exception']),
        ];
    }
}
```

and added that to our `fluent.php`-config
```php
...
'handler' => FluentHandler::class,
...
```