### PR TITLE
Add support for monolog processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ return [
     /** @see https://github.com/fluent/fluent-logger-php/blob/master/src/PackerInterface.php */
     // specified class name
     'packer' => null,
+    
+    // optionally override Ytake\LaravelFluent\FluentHandler class to customize behaviour
+    'handler' => null,
+    
+    'processors' => [],
 
     'tagFormat' => '{{channel}}.{{level_name}}',
 ];
@@ -193,6 +198,39 @@ example (production)
 <match lumen.**>
   type stdout
 </match>
+```
+
+## Monolog processors
+
+You can add processors to the monolog handlers by adding them to the `processors` array within the `fluent.php` config.
+
+config/fluent.php:
+```php
+'processors' => [function($record) {
+    $record['extra']['level'] = $record['level_name'];
+    
+    return $record;
+}],
+```
+
+Alternatively, you can pass the class name of the processor.  This helps keep your config compatible with `config:cache`
+
+config/fluent.php:
+```php
+'processors' => [CustomProcessor::class],
+```
+
+CustomProcessor.php:
+```php
+class CustomProcessor
+{
+    public function __invoke($record)
+    {
+        $record['extra']['level'] = $record['level_name'];
+
+        return $record;
+    }
+}
 ```
 
 ## Author ##

--- a/src/FluentLogManager.php
+++ b/src/FluentLogManager.php
@@ -63,7 +63,8 @@ final class FluentLogManager extends LogManager
     {
         $configure = $this->app->make('config')['fluent'];
         $fluentHandler = $this->detectHandler($configure);
-        return new $fluentHandler(
+
+        $handler = new $fluentHandler(
             new FluentLogger(
                 $configure['host'] ?? FluentLogger::DEFAULT_ADDRESS,
                 (int)$configure['port'] ?? FluentLogger::DEFAULT_LISTEN_PORT,
@@ -73,6 +74,18 @@ final class FluentLogManager extends LogManager
             $configure['tagFormat'] ?? null,
             $this->level($config)
         );
+
+        if (isset($configure['processors']) && is_array($configure['processors'])) {
+            foreach ($configure['processors'] as $processor) {
+                if (is_string($processor) && class_exists($processor)) {
+                    $processor = $this->app->make($processor);
+                }
+
+                $handler->pushProcessor($processor);
+            }
+        }
+
+        return $handler;
     }
 
     /**

--- a/src/config/fluent.php
+++ b/src/config/fluent.php
@@ -33,5 +33,7 @@ return [
     // optionally override Ytake\LaravelFluent\FluentHandler class to customize behaviour
     'handler' => null,
 
+    'processors' => [],
+
     'tagFormat' => '{{channel}}.{{level_name}}',
 ];

--- a/tests/LogManagerTest.php
+++ b/tests/LogManagerTest.php
@@ -6,6 +6,7 @@ namespace Tests;
 
 use Fluent\Logger\FluentLogger;
 use Illuminate\Log\Logger;
+use Monolog\Processor\MemoryUsageProcessor;
 use Ytake\LaravelFluent\FluentHandler;
 use Ytake\LaravelFluent\FluentLogManager;
 
@@ -43,5 +44,49 @@ final class LogManagerTest extends TestCase
         /** @var FluentHandler $handler */
         $this->assertInstanceOf(FluentLogger::class, $fluent = $handler->getLogger());
         $this->assertInstanceOf(StubPacker::class, $fluent->getPacker());
+    }
+
+    /**
+     * This should be valid:
+     *
+     * 'processors' => [new Monolog\Processor\MemoryUsageProcessor()],
+     */
+    public function testAddObjectAsProcessor(): void
+    {
+        $processor = new MemoryUsageProcessor();
+
+        $this->app['config']->set('fluent.processors', [$processor]);
+        $this->logManager->setDefaultDriver('fluent');
+
+        /** @var \Illuminate\Log\Logger $logger */
+        $logDriver = $this->logManager->driver();
+
+        /** @var \Ytake\LaravelFluent\FluentHandler::class $logger */
+        $logger = $logDriver->getLogger()->getHandlers()[0];
+        $actualProcessor = $logger->popProcessor();
+
+        $this->assertEquals($processor, $actualProcessor);
+    }
+
+    /**
+     * This should be valid:
+     *
+     * 'processors' => [Monolog\Processor\MemoryUsageProcessor::class],
+     */
+    public function testAddStringAsProcessor(): void
+    {
+        $processor = MemoryUsageProcessor::class;
+
+        $this->app['config']->set('fluent.processors', [$processor]);
+        $this->logManager->setDefaultDriver('fluent');
+
+        /** @var \Illuminate\Log\Logger $logger */
+        $logDriver = $this->logManager->driver();
+
+        /** @var \Ytake\LaravelFluent\FluentHandler::class $logger */
+        $logger = $logDriver->getLogger()->getHandlers()[0];
+        $actualProcessor = $logger->popProcessor();
+
+        $this->assertInstanceOf(MemoryUsageProcessor::class, $actualProcessor);
     }
 }


### PR DESCRIPTION
This will cause FluentLogManager to add processors to the handler at the time of creation. This is a simple feature that saves us from having to try and pull the handler out of the container later to configure processors on the fluent handler.

This helps with modifying the message between Laravel and fluent to add meta data:

```
'processors' => [function($record) {
    $record['extra']['level'] = $record['level_name'];
    
    return $record;
}],
```