### PR TITLE
Laravel 10 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '8.0']
+        php-versions: ['8.1', '8.2']
     name: PHP ${{ matrix.php-versions }} Test
     steps:
     - uses: actions/checkout@v2

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -21,7 +21,7 @@ checks:
 build:
     environment:
         php:
-            version: 8.0.2
+            version: 8.1.2
             ini:
                 "xdebug.mode": coverage
     tests:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ fluent logger for laravel
 [![Latest Version](http://img.shields.io/packagist/v/ytake/laravel-fluent-logger.svg?style=flat-square)](https://packagist.org/packages/ytake/laravel-fluent-logger)
 [![Total Downloads](http://img.shields.io/packagist/dt/ytake/laravel-fluent-logger.svg?style=flat-square)](https://packagist.org/packages/ytake/laravel-fluent-logger)
 
+## Versions
+
+| Framework             | Library                        |
+|-----------------------|---------------------------------|
+| Laravel / Lumen < v10 | ytake/laravel-fluent-logger: ^5 |
+| Laravel / Lumen v10   | ytake/laravel-fluent-logger: ^6 |
+
+
+
 ## usage
 
 ### Installation For Laravel
@@ -25,7 +34,7 @@ or composer.json
 
 ```json
 "require": {
-  "ytake/laravel-fluent-logger": "^5.0"
+  "ytake/laravel-fluent-logger": "^6.0"
 },
 ```
 
@@ -206,8 +215,8 @@ You can add processors to the monolog handlers by adding them to the `processors
 
 config/fluent.php:
 ```php
-'processors' => [function($record) {
-    $record['extra']['level'] = $record['level_name'];
+'processors' => [function (\Monolog\LogRecord $record) {
+    $record->extra['level'] = $record['level_name'];
     
     return $record;
 }],
@@ -224,9 +233,9 @@ CustomProcessor.php:
 ```php
 class CustomProcessor
 {
-    public function __invoke($record)
+    public function __invoke(\Monolog\LogRecord $record)
     {
-        $record['extra']['level'] = $record['level_name'];
+        $record->extra['level'] = $record['level_name'];
 
         return $record;
     }

--- a/README.md
+++ b/README.md
@@ -209,6 +209,27 @@ example (production)
 </match>
 ```
 
+## Tag format
+
+The tag format can be configured to take variables from the [LogEntry](https://github.com/Seldaek/monolog/blob/main/src/Monolog/LogRecord.php) 
+object.  This will then be used to match tags in fluent.
+
+`{{channel}}` will be [Laravel's current environment](https://laravel.com/docs/10.x/logging#configuring-the-channel-name) as configured in 
+`APP_ENV`, NOT the logging channel from `config/logging.php`
+
+`{{level_name}}` will be the [uppercase string version of the log level](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Level.php#L136).
+
+`{{level}}` is the [numeric value](https://github.com/Seldaek/monolog/blob/main/src/Monolog/Level.php) of the log level.  Debug == 100, etc
+
+You can also use variables that exist in `LogEntry::$extra`.  Given a message like
+
+```php
+$l = new \Monolog\LogRecord(extra: ['foo' => 'bar']);
+```
+
+You could use a tag format of `myapp.{{foo}}` to produce a tag of `myapp.bar`.
+
+
 ## Monolog processors
 
 You can add processors to the monolog handlers by adding them to the `processors` array within the `fluent.php` config.
@@ -216,7 +237,7 @@ You can add processors to the monolog handlers by adding them to the `processors
 config/fluent.php:
 ```php
 'processors' => [function (\Monolog\LogRecord $record) {
-    $record->extra['level'] = $record['level_name'];
+    $record->extra['cloudwatch_log_group'] = 'test_group';
     
     return $record;
 }],
@@ -235,7 +256,7 @@ class CustomProcessor
 {
     public function __invoke(\Monolog\LogRecord $record)
     {
-        $record->extra['level'] = $record['level_name'];
+        $record->extra['cloudwatch_log_group'] = 'test_group';
 
         return $record;
     }

--- a/composer.json
+++ b/composer.json
@@ -17,21 +17,21 @@
     }
   ],
   "require": {
-    "php": "^7.3|^8.0.2",
+    "php": "^8.1",
     "fluent/logger": "^1.0",
-    "illuminate/log": "^8.0||^9.0",
-    "illuminate/support": "^8.0||^9.0",
-    "illuminate/config": "^8.0||^9.0",
-    "illuminate/contracts": "^8.0||^9.0",
-    "illuminate/container": "^8.0||^9.0",
-    "illuminate/events": "^8.0||^9.0",
-    "monolog/monolog": "^2.0"
+    "illuminate/log": "^10.0",
+    "illuminate/support": "^10.0",
+    "illuminate/config": "^10.0",
+    "illuminate/contracts": "^10.0",
+    "illuminate/container": "^10.0",
+    "illuminate/events": "^10.0",
+    "monolog/monolog": "^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0",
     "php-coveralls/php-coveralls": "^2.4",
-    "illuminate/filesystem": "^8.0||^9.0",
-    "phpstan/phpstan": "^0.12",
+    "illuminate/filesystem": "^10.0",
+    "phpstan/phpstan": "^1.10",
     "slevomat/coding-standard": "^6.4",
     "squizlabs/php_codesniffer": "^3.5",
     "doctrine/coding-standard": "^8.2"
@@ -66,5 +66,10 @@
     "qa": [
       "@test" ,"@cs", "@sa"
     ]
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,5 @@ parameters:
   paths:
     - src
   level: max
-  excludes_analyse:
+  excludePaths:
     - src/LogServiceProvider.php

--- a/src/FluentHandler.php
+++ b/src/FluentHandler.php
@@ -34,8 +34,6 @@ use function str_replace;
 
 /**
  * FluentHandler
- *
- * @phpstan-import-type Level from \Monolog\Logger
  */
 class FluentHandler extends AbstractProcessingHandler
 {
@@ -101,9 +99,9 @@ class FluentHandler extends AbstractProcessingHandler
     /**
      * returns the context
      *
-     * @param array $context
+     * @param array<string, mixed> $context
      *
-     * @return array|string
+     * @return array<string, mixed>|string
      */
     protected function getContext(array $context): array|string
     {
@@ -117,7 +115,7 @@ class FluentHandler extends AbstractProcessingHandler
     /**
      * Identifies the content type of the given $context
      *
-     * @param  array $context
+     * @param  array<string, mixed> $context
      *
      * @return bool
      */
@@ -132,7 +130,7 @@ class FluentHandler extends AbstractProcessingHandler
     /**
      * Returns the entire exception trace as a string
      *
-     * @param  array<string, mixed> $context
+     * @param  array{'exception': Exception} $context
 
      * @return string
      */

--- a/src/FluentHandler.php
+++ b/src/FluentHandler.php
@@ -23,10 +23,11 @@ use Exception;
 use Fluent\Logger\LoggerInterface;
 use LogicException;
 use Monolog\Handler\AbstractProcessingHandler;
-use Monolog\Logger;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Psr\Log\LogLevel;
 
 use function array_key_exists;
-use function is_array;
 use function preg_match_all;
 use function sprintf;
 use function str_replace;
@@ -38,73 +39,59 @@ use function str_replace;
  */
 class FluentHandler extends AbstractProcessingHandler
 {
-    /** @var LoggerInterface */
-    protected $logger;
-
-    /** @var string */
-    protected $tagFormat = '{{channel}}.{{level_name}}';
+    protected string $tagFormat = '{{channel}}.{{level_name}}';
 
     /**
-     * @param LoggerInterface $logger
-     * @param null|string     $tagFormat
-     * @param int             $level
-     * @param bool            $bubble
+     * @param LoggerInterface              $logger
+     * @param null|string                  $tagFormat
+     * @param int|string|Level|LogLevel::* $level
+     * @param bool                         $bubble
      *
-     * @phpstan-param Level $level
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
      */
     public function __construct(
-        LoggerInterface $logger,
+        protected LoggerInterface $logger,
         string $tagFormat = null,
-        int $level = Logger::DEBUG,
+        Level|int|string $level = Level::Debug,
         bool $bubble = true
     ) {
-        $this->logger = $logger;
         if ($tagFormat !== null) {
             $this->tagFormat = $tagFormat;
         }
         parent::__construct($level, $bubble);
     }
 
-    /**
-     * @param array<string, mixed> $record
-     */
-    protected function write(array $record): void
+    protected function write(LogRecord $record): void
     {
         $tag = $this->populateTag($record);
         $this->logger->post(
             $tag,
             [
-                'message' => $record['message'],
-                'context' => $this->getContext($record['context']),
-                'extra'   => $record['extra'],
+                'message' => $record->message,
+                'context' => $this->getContext($record->context),
+                'extra'   => $record->extra,
             ]
         );
     }
 
-    /**
-     * @param array<string, mixed> $record
-     *
-     * @return string
-     */
-    protected function populateTag(array $record): string
+    protected function populateTag(LogRecord $record): string
     {
         return $this->processFormat($record, $this->tagFormat);
     }
 
-    /**
-     * @param array<string, mixed>  $record
-     * @param string $tag
-     *
-     * @return string
-     */
-    protected function processFormat(array $record, string $tag): string
+    protected function processFormat(LogRecord $record, string $tag): string
     {
         if (preg_match_all('/{{(.*?)}}/', $tag, $matches)) {
             foreach ($matches[1] as $match) {
-                if (!isset($record[$match])) {
+                if (isset($record[$match])) {
+                    $arr = $record;
+                } elseif (isset($record->extra[$match])) {
+                    $arr = $record->extra;
+                } else {
                     throw new LogicException('No such field in the record');
                 }
-                $tag = str_replace(sprintf('{{%s}}', $match), $record[$match], $tag);
+
+                $tag = str_replace(sprintf('{{%s}}', $match), $arr[$match], $tag);
             }
         }
 
@@ -114,11 +101,11 @@ class FluentHandler extends AbstractProcessingHandler
     /**
      * returns the context
      *
-     * @param mixed $context
+     * @param array $context
      *
-     * @return mixed
+     * @return array|string
      */
-    protected function getContext($context)
+    protected function getContext(array $context): array|string
     {
         if ($this->contextHasException($context)) {
             return $this->getContextExceptionTrace($context);
@@ -130,15 +117,14 @@ class FluentHandler extends AbstractProcessingHandler
     /**
      * Identifies the content type of the given $context
      *
-     * @param  mixed $context
+     * @param  array $context
      *
      * @return bool
      */
-    protected function contextHasException($context): bool
+    protected function contextHasException(array $context): bool
     {
         return (
-            is_array($context)
-            && array_key_exists('exception', $context)
+            array_key_exists('exception', $context)
             && $context['exception'] instanceof Exception
         );
     }

--- a/src/FluentLogManager.php
+++ b/src/FluentLogManager.php
@@ -34,12 +34,10 @@ use function strval;
 
 /**
  * FluentLogManager
+ * @property Container $app
  */
 final class FluentLogManager extends LogManager
 {
-    /** @var Container */
-    protected $app;
-
     /**
      * @param array<string, mixed> $config
      * @return LoggerInterface
@@ -115,10 +113,8 @@ final class FluentLogManager extends LogManager
      */
     protected function detectPacker(array $configure): ?PackerInterface
     {
-        if (!is_null($configure['packer'])) {
-            if (class_exists($configure['packer'])) {
-                return $this->app->make($configure['packer']);
-            }
+        if (!is_null($configure['packer']) && class_exists($configure['packer'])) {
+            return $this->app->make($configure['packer']);
         }
         return null;
     }
@@ -131,10 +127,8 @@ final class FluentLogManager extends LogManager
     protected function detectHandler(array $configure): string
     {
         $handler = $configure['handler'] ?? null;
-        if (!is_null($handler)) {
-            if (class_exists($handler)) {
-                return strval($handler);
-            }
+        if (!is_null($handler) && class_exists($handler)) {
+            return strval($handler);
         }
         return $this->defaultHandler();
     }

--- a/tests/LogManagerTest.php
+++ b/tests/LogManagerTest.php
@@ -14,8 +14,7 @@ use function assert;
 
 final class LogManagerTest extends TestCase
 {
-    /** @var FluentLogManager */
-    private $logManager;
+    private FluentLogManager $logManager;
 
     protected function setUp(): void
     {

--- a/tests/StubLogger.php
+++ b/tests/StubLogger.php
@@ -12,17 +12,10 @@ use function serialize;
 
 final class StubLogger implements LoggerInterface
 {
-    /** @var Filesystem */
-    protected $filesystem;
-
-    public function __construct(Filesystem $filesystem)
+    public function __construct(protected Filesystem $filesystem)
     {
-        $this->filesystem = $filesystem;
     }
 
-    /**
-     * @param array $data
-     */
     public function post($tag, array $data): void
     {
         $this->filesystem->put(__DIR__ . '/tmp/put.log', serialize([$tag, $data]));


### PR DESCRIPTION
This adds support for Laravel 10, which is a major change.

Laravel 10 requires monolog: ^3.  See [Laravel 10 upgrade instructions](https://laravel.com/docs/10.x/upgrade#monolog-3).  This has changed a number of function signatures in `AbstractProcessingHandler` (that `FluentHandler` extends) to use new `LogRecord` objects instead of arrays.  [See Monolog upgrade instructions](https://github.com/Seldaek/monolog/blob/main/UPGRADE.md).

Due to this, this version will not work with Laravel <10.  I've removed those as possible dependencies.  I've also bumped the required PHP version to ^8.1 as that's what both laravel:^10 and monoglog:^3 require.

Another breaking change is caused by the `LogRecord` change.  `AbstractProcessingHandler::handle()` used to have this signature:

```php
public function handle(array $record): bool
{ }
```

I don't know who was doing it, but it was possible to pass arbitrary values in this array for use with `FluentHandler::$tagFormat`.  An example, where `foo` and `testing` are supplied:

```php
$handler->handle([
    'message' => 'testing',
    'level' => Logger::DEBUG,
    'extra' => [],
    'channel' => 'testing',
    'level_name' => 'testing',
    'testing' => 'logger',
    'foo' => 'bar',
    'context' => ['testing'],
]);
```

The new signature is:

```php
public function handle(LogRecord $record): bool
{ }
```

and you cannot set strange variables on the root of the object.  For this reason I have changed `FluentHandler::processFormat()`
to check for both `LogRecord` fields and `LogRecord::$extra` fields for tags.

```php
protected function processFormat(LogRecord $record, string $tag): string
{
    if (preg_match_all('/{{(.*?)}}/', $tag, $matches)) {
        foreach ($matches[1] as $match) {
            if (isset($record[$match])) {
                $arr = $record;
            } elseif (isset($record->extra[$match])) {
                $arr = $record->extra;
            } else {
                throw new LogicException('No such field in the record');
            }

            $tag = str_replace(sprintf('{{%s}}', $match), $arr[$match], $tag);
        }
    }

    return $tag;
}
```

I've updated the readme to explain.

This is a breaking change, and should bump major to v6.  Also, I request that the current commit of dev-main get a v5 tag, as this library didn't get a version tagged when it gained Laravel v9 support.